### PR TITLE
Add NULL Definition in Callback.h

### DIFF
--- a/cores/arduino/Callback.h
+++ b/cores/arduino/Callback.h
@@ -28,6 +28,10 @@
 
 #pragma once
 
+#ifndef NULL
+#define NULL  0
+#endif
+
 class Callback {
 public:
     Callback() : _callback(NULL), _context(nullptr) {  }


### PR DESCRIPTION
This PR addresses issue #133, and adds a NULL definition in Callback.h.