### PR TITLE
Wire: Let requestFrom return the number of available bytes

### DIFF
--- a/libraries/Wire/src/Wire.cpp
+++ b/libraries/Wire/src/Wire.cpp
@@ -229,7 +229,7 @@ size_t TwoWire::requestFrom(uint8_t address, size_t size, bool stopBit)
         _rx_write = size;
     }
 
-    return size;
+    return _rx_write;
 }
 
 size_t TwoWire::write(uint8_t data)


### PR DESCRIPTION
Previously, it would return the number of requested bytes, even if the
slave returned a NAK on the address byte, preventing libraries to detect
such a NAK. For example, the SparkFun HTU21D library would fail to read
humidity, because the "I'm not ready measuring"-NAK would look like a
successful read, but with dummy data.

This matches the return value with that of the official Arduino versions
and the documentation at
https://www.arduino.cc/en/Reference/WireRequestFrom