### PR TITLE
Disable USB pullup when stopping USB

### DIFF
--- a/system/STM32L0xx/Source/USB/HAL/Src/stm32l0xx_hal_pcd.c
+++ b/system/STM32L0xx/Source/USB/HAL/Src/stm32l0xx_hal_pcd.c
@@ -240,7 +240,7 @@ HAL_StatusTypeDef HAL_PCD_DeInit(PCD_HandleTypeDef *hpcd)
   hpcd->State = HAL_PCD_STATE_BUSY;
 
   /* Stop Device */
-  (void)HAL_PCD_Stop(hpcd);
+  (void)USB_StopDevice(hpcd->Instance);
 
 #if (USE_HAL_PCD_REGISTER_CALLBACKS == 1U)
   if (hpcd->MspDeInitCallback == NULL)
@@ -998,7 +998,7 @@ HAL_StatusTypeDef HAL_PCD_Stop(PCD_HandleTypeDef *hpcd)
   __HAL_LOCK(hpcd);
   __HAL_PCD_DISABLE(hpcd);
 
-  (void)USB_StopDevice(hpcd->Instance);
+  (void)USB_DevDisconnect(hpcd->Instance);
 
   __HAL_UNLOCK(hpcd);
 


### PR DESCRIPTION
It turns out that stopping the USB peripheral does not automatically
reset this pullup, so stopping USB (e.g. through USBDevice.detach())
would let the pullup enabled, making the USB host think the board was
still connected (but any subsequent communication would fail).
Additionally, this would use around 300μA of current.

This is a bug in the USB HAL used. This commit backports a small change
from the HAL v1.11.3 to fix this.

This fixes #171