### PR TITLE
Rename nucleo-l053rb.cfg to nucleo-l053r8.cfg

### DIFF
--- a/variants/NUCLEO-L053R8/openocd_scripts/nucleo-l053r8.cfg
+++ b/variants/NUCLEO-L053R8/openocd_scripts/nucleo-l053r8.cfg
@@ -1,4 +1,4 @@
-# This is a NUCLEO-64 board with a single STM32L053RB chip.
+# This is a NUCLEO-64 board with a single STM32L053R8 chip.
 #
 
 source [find interface/stlink.cfg]


### PR DESCRIPTION
Testing with a Nucleo STM32L053R8 showed an error message, which pointed to a misspelling of the board name in the config filename.